### PR TITLE
Cleanup

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -3,8 +3,8 @@
 # Installation script customize.sh for Magisk Module Systemless Debloater (REPLACE).
 # XDA thread: https://forum.xda-developers.com/mi-9t/how-to/magisk-module-systemless-debloater-t4180083
 # GitHub source: https://github.com/zgfg/SystemlessDebloater
-# Module debloates /system, /system_ext, /product, /vendor and /india apps by searching (at the time of module installation) and listing their paths to the Magisk Module Installer REPLACE variable. 
-# Magisk then creates local system tree that will be (systemlessly) overlaid into the /system at every (re)boot. 
+# Module debloates /system, /system_ext, /product, /vendor and /india apps by searching (at the time of module installation) and listing their paths to the Magisk Module Installer REPLACE variable.
+# Magisk then creates local system tree that will be (systemlessly) overlaid into the /system at every (re)boot.
 # It can be used for any Android - just add/remove your unwanted Stock app names to /Download/SystemlessDebloaterList.sh script on Internal memory, (re)install the module and reboot.
 # Log will be saved to /Download/SystemlessDebloater.log also to Internal memory.
 # Before debloating the apps, from Settings/Applications, Uninstall (updates) and Clear Data for them!
@@ -35,18 +35,15 @@ echo '' >> $LogFile
 Prop=$(getprop ro.build.version.release)
 PrintLine='Android '$Prop
 Prop=$(getprop ro.build.system_root_image)
-if [ ! -z "$Prop" ] && [ "$Prop" ]
-then
+if [ ! -z "$Prop" ] && [ "$Prop" ]; then
 	PrintLine=$PrintLine' SAR'
 fi
 Prop=$(getprop ro.build.ab_update)
-if [ ! -z "$Prop" ] && [ "$Prop" ]
-then
+if [ ! -z "$Prop" ] && [ "$Prop" ]; then
 	PrintLine=$PrintLine' A/B'
 fi
 Prop=$(getprop ro.boot.slot_suffix)
-if [ ! -z "$Prop" ] && [ "$Prop" ]
-then
+if [ ! -z "$Prop" ] && [ "$Prop" ]; then
 	PrintLine=$PrintLine" ($Prop)"
 fi
 echo "$PrintLine"
@@ -59,14 +56,14 @@ echo '' >> $LogFile
 # Default SAR mount-points (SAR partitions to search for debloating)
 SarMountPointList="/product /vendor /system_ext /india /my_bigball"
 
-# Default/empty list of app names for debloating and debloated app names 
+# Default/empty list of app names for debloating and debloated app names
 DebloatList=""
 DebloatedList=""
 
-# Verbose logging 
+# Verbose logging
 VerboseLog="true"
 
-# Searching for possible several instances of Stock apps for debloating  
+# Searching for possible several instances of Stock apps for debloating
 MultiDebloat="true"
 
 
@@ -75,19 +72,18 @@ MultiDebloat="true"
 
 # Input file with a list of app names for debloating
 DebloatListFile=$LogFolder/SystemlessDebloaterList.sh
-PrintLine="Input debloat list file: $DebloatListFile"												 					  
+PrintLine="Input debloat list file: $DebloatListFile"
 echo "$PrintLine"
 echo "$PrintLine" >> $LogFile
 echo '' >> $LogFile
 
 # Check if the input list file exists
-if [ -f $DebloatListFile ]
-then
+if [ -f $DebloatListFile ]; then
 	# Source the input file
 	. $DebloatListFile
 else
 	# Log error
-	PrintLine='Input file not found, creating a template file!'																					   
+	PrintLine='Input file not found, creating a template file!'
 	echo "$PrintLine"
 	echo "$PrintLine" >> $LogFile
 	echo "# Input debloat list $DebloatListFile for Magisk Module Systemless Debloater (REPLACE) $MyVersion" > $DebloatListFile
@@ -98,12 +94,12 @@ else
 	echo '# Define a list of Stock apps for debloating:' >> $DebloatListFile
 	echo 'DebloatList=""' >> $DebloatListFile
 	echo ' ' >> $DebloatListFile
-	echo '# MIUI Example (commented out):' >> $DebloatListFile	
-	echo '# DebloatList="AnalyticsCore AntHalService BasicDreams ' >> $DebloatListFile 
+	echo '# MIUI Example (commented out):' >> $DebloatListFile
+	echo '# DebloatList="AnalyticsCore AntHalService BasicDreams ' >> $DebloatListFile
 	echo '# BookmarkProvider CatchLog Chrome CneApp EasterEgg ' >> $DebloatListFile
 	echo '# facebook-appmanager facebook-installer facebook-services ' >> $DebloatListFile
-	echo '# FileExplorer_old GlobalFashiongallery GlobalMinusScreen ' >> $DebloatListFile 
-	echo '# Gmail2 GoogleFeedback GooglePartnerSetup HybridAccessory ' >> $DebloatListFile 
+	echo '# FileExplorer_old GlobalFashiongallery GlobalMinusScreen ' >> $DebloatListFile
+	echo '# Gmail2 GoogleFeedback GooglePartnerSetup HybridAccessory ' >> $DebloatListFile
 	echo '# HybridPlatform IdMipay InMipay Joyose MiBrowserGlobal ' >> $DebloatListFile
 	echo '# MiBrowserGlobalVendor MiCreditInStub MiDrop ' >> $DebloatListFile
 	echo '# MiLinkService2 MiPicks MiPlayClient MiRcs MiRecycle ' >> $DebloatListFile
@@ -123,7 +119,7 @@ echo '' >> $LogFile
 Packages=$(pm list packages -f | sed 's!^package:!!g')
 
 
-# Log input SarMountPointList 
+# Log input SarMountPointList
 echo 'Input SarMountPointList="'"$SarMountPointList"'"' >> $LogFile
 echo '' >> $LogFile
 
@@ -132,8 +128,7 @@ NewList="/system $SarMountPointList "
 
 # Search through packages to add potential mount points
 NewList="$SarMountPointList"$'\n'
-for PackageInfo in $Packages
-do
+for PackageInfo in $Packages; do
 	# Extract potential mount point path from PackageInfo
 	Path=$(echo "$PackageInfo" | cut -d '/' -f 2)
 
@@ -149,44 +144,37 @@ BannedList="/data /apex /framework"
 
 # Exclude not valid paths from SarMountPointList
 SarMountPointList=""
-for Path in $NewList
-do
+for Path in $NewList; do
 	# Skip not valid paths
-	for BannedPath in $BannedList
-	do
-		if [ "$Path" = "$BannedPath" ]
-		then
+	for BannedPath in $BannedList; do
+		if [ "$Path" = "$BannedPath" ]; then
 			Path=""
 			break
 		fi
 	done
 
 	# Append to SarMountPointList
-	if [ ! -z "$Path" ]
-	then
+	if [ ! -z "$Path" ]; then
 		SarMountPointList="$SarMountPointList$Path"$'\n'
-	fi	
+	fi
 done
 
-# Log final SarMountPointList 
+# Log final SarMountPointList
 echo 'Final SarMountPointList="'$'\n'"$SarMountPointList"'"' >> $LogFile
 echo '' >> $LogFile
 
 
 # List Stock packages
 PackageInfoList=""
-for PackageInfo in $Packages
-do
+for PackageInfo in $Packages; do
 	# Include only applications from SAR mount points
-	for SarMountPoint in $SarMountPointList
-	do		
-		if [ -z $(echo "$PackageInfo" | grep '^$SarMountPoint/') ]
-		then
+	for SarMountPoint in $SarMountPointList; do
+		if [ -z $(echo "$PackageInfo" | grep '^$SarMountPoint/') ]; then
 			PrepPackageInfo=$PackageInfo
 
 			# Append to the PackageInfoList
 			PackageInfoList="$PackageInfoList$PrepPackageInfo"$'\n'
-			
+
 			break
 		fi
 	done
@@ -196,18 +184,16 @@ done
 PackageInfoList=$(echo "$PackageInfoList" | sort -bu )
 
 
-# Log input DebloatList 
+# Log input DebloatList
 echo 'Input DebloatList="'"$DebloatList"'"' >> $LogFile
 echo '' >> $LogFile
 
 #Search for Stock apps
 StockAppList=""
-for SarMountPoint in $SarMountPointList
-do
+for SarMountPoint in $SarMountPointList; do
 	NewList=$(find "$SarMountPoint/" -type f -name "*.apk" 2> /dev/null)
 
-	if [ ! -z "$NewList" ]
-	then
+	if [ ! -z "$NewList" ]; then
 		StockAppList="$StockAppList$NewList"$'\n'
 	fi
 done
@@ -218,12 +204,10 @@ done
 
 #Search for previously debloated Stock apps
 ReplacedAppList=""
-for SarMountPoint in $SarMountPointList 
-do
+for SarMountPoint in $SarMountPointList; do
 	NewList=$(find "$SarMountPoint/" -type f -name ".replace" 2> /dev/null)
 
-	if [ ! -z "$NewList" ]
-	then
+	if [ ! -z "$NewList" ]; then
 		ReplacedAppList="$ReplacedAppList$NewList"$'\n'
 	fi
 done
@@ -253,8 +237,7 @@ echo 'ServiceLogFolder=/data/local/tmp' >> $ServiceScript
 echo 'ServiceLogFile=$ServiceLogFolder/SystemlessDebloater-service.log' >> $ServiceScript
 echo '' >> $ServiceScript
 
-if [ ! -z "$VerboseLog" ]
-then
+if [ ! -z "$VerboseLog" ]; then
 	echo 'echo "Execution time: $(date +%c)" > $ServiceLogFile' >> $ServiceScript
 	echo 'echo "" >> $ServiceLogFile' >> $ServiceScript
 else
@@ -265,24 +248,22 @@ echo '' >> $ServiceScript
 # Module's own folder
 MODDIR=$(echo "$MODPATH" | sed "s!/modules_update/!/modules/!")
 echo "MODDIR=$MODDIR" >> $ServiceScript
-								   
 
-if [ ! -z "$VerboseLog" ]
-then	
-	echo 'echo "MODDIR: $MODDIR" >> $ServiceLogFile' >> $ServiceScript								
-	echo 'echo "" >> $ServiceLogFile' >> $ServiceScript								
+
+if [ ! -z "$VerboseLog" ]; then
+	echo 'echo "MODDIR: $MODDIR" >> $ServiceLogFile' >> $ServiceScript
+	echo 'echo "" >> $ServiceLogFile' >> $ServiceScript
 	echo '' >> $ServiceScript
 fi
 
 # Dummy apk used for debloating
-echo 'DummyApk=$MODDIR/dummy.apk' >> $ServiceScript							   
-echo 'touch $DummyApk' >> $ServiceScript							   
+echo 'DummyApk=$MODDIR/dummy.apk' >> $ServiceScript
+echo 'touch $DummyApk' >> $ServiceScript
 echo '' >> $ServiceScript
 
-if [ ! -z "$VerboseLog" ]
-then
-	echo 'echo "DummyApk: $DummyApk" >> $ServiceLogFile' >> $ServiceScript							
-	echo 'echo "" >> $ServiceLogFile' >> $ServiceScript							
+if [ ! -z "$VerboseLog" ]; then
+	echo 'echo "DummyApk: $DummyApk" >> $ServiceLogFile' >> $ServiceScript
+	echo 'echo "" >> $ServiceLogFile' >> $ServiceScript
 	echo '' >> $ServiceScript
 fi
 
@@ -299,59 +280,50 @@ DebloatList=$(echo "$DebloatList" | sort -bu )
 
 # Iterate through apps for debloating
 echo 'Debloating:' >> $LogFile
-for AppName in $DebloatList
-do
+for AppName in $DebloatList; do
 	AppFound=""
 
-	#Search through previously debloated Stock apps	
+	#Search through previously debloated Stock apps
 	SearchName=/"$AppName"/.replace
 	SearchList=$(echo "$ReplacedAppList" | grep "$SearchName$")
-	for FilePath in $SearchList
-	do
+	for FilePath in $SearchList; do
 		# Break if app already found
-		if [ -z "$MultiDebloat" ]
-		then
-			if [ ! -z "$AppFound" ] 
-			then
-				break					
+		if [ -z "$MultiDebloat" ]; then
+			if [ ! -z "$AppFound" ]; then
+				break
 			fi
 		fi
-	
+
 		# Remove /filename from the end of the path
 		FileName=${FilePath##*/}
 		FolderPath=$(echo "$FilePath" | sed "s,/$FileName$,,")
-					
-		if [ ! -z "FolderPath" ]
-		then
+
+		if [ ! -z "FolderPath" ]; then
 			AppFound="true"
 
 			# Log the full path
 			echo "found: $FilePath" >> $LogFile
-				
-			if [ -z $(echo "$FolderPath" | grep '^/system/') ]
-			then
+
+			if [ -z $(echo "$FolderPath" | grep '^/system/') ]; then
 				# Append to MountList with appended AppName
-				MountList="$MountList$FolderPath/$AppName.apk"$'\n'			
+				MountList="$MountList$FolderPath/$AppName.apk"$'\n'
 			else
 				# Append to REPLACE list
-				REPLACE="$REPLACE$FolderPath"$'\n'			
+				REPLACE="$REPLACE$FolderPath"$'\n'
 			fi
-			
+
 			# Append to DebloatedList
 			DebloatedList="$DebloatedList$AppName"$'\n'
 		fi
 	done
 
-	#Search through Stock apps	
+	#Search through Stock apps
 	SearchName=/"$AppName".apk
 	SearchList=$(echo "$StockAppList" | grep "$SearchName$")
-	for FilePath in $SearchList
-	do
-		if [ -z "$MultiDebloat" ]
-		then
-			if [ ! -z "$AppFound" ] 
-			then
-				break					
+	for FilePath in $SearchList; do
+		if [ -z "$MultiDebloat" ]; then
+			if [ ! -z "$AppFound" ]; then
+				break
 			fi
 		fi
 
@@ -360,39 +332,35 @@ do
 		PackageName=""
 
 		# Extract package name
-		if [ ! -z "$PackageInfo" ]
-		then
+		if [ ! -z "$PackageInfo" ]; then
 			PackageName=$(echo "$PackageInfo" | sed "s!^$FilePath=!!")
 			PackageName="($PackageName) "
 		fi
-			
+
 		# Remove /filename from the end of the path
 		FileName=${FilePath##*/}
 		FolderPath=$(echo "$FilePath" | sed "s,/$FileName$,,")
-					
-		if [ ! -z "FolderPath" ]
-		then
+
+		if [ ! -z "FolderPath" ]; then
 			AppFound="true"
 
 			# Log the full path and package name
 			echo "found: $FilePath $PackageName" >> $LogFile
 
-			if [ -z $(echo "$FolderPath" | grep '^/system/') ]
-			then
+			if [ -z $(echo "$FolderPath" | grep '^/system/') ]; then
 				# Append to MountList
-				MountList="$MountList$FilePath"$'\n'			
+				MountList="$MountList$FilePath"$'\n'
 			else
 				# Append to REPLACE list
-				REPLACE="$REPLACE$FolderPath"$'\n'			
+				REPLACE="$REPLACE$FolderPath"$'\n'
 			fi
-			
+
 			# Append to DebloatedList
 			DebloatedList="$DebloatedList$AppName"$'\n'
 		fi
 	done
-	
-	if [ -z "$AppFound" ]
-	then
+
+	if [ -z "$AppFound" ]; then
 		# Log app name if not found
 		PrintLine="$AppName --- app not found!"
 		echo "$PrintLine"
@@ -401,8 +369,7 @@ do
 done
 echo '' >> $LogFile
 
-if [ -z "$REPLACE" ]
-then
+if [ -z "$REPLACE" ]; then
 	PrintLine="No app for debloating found!"
 	echo "$PrintLine"
 	echo "$PrintLine" >> $LogFile
@@ -422,22 +389,20 @@ REPLACE=$(echo "$REPLACE" | sort -bu )
 echo 'REPLACE="'"$REPLACE"$'\n"' >> $LogFile
 echo '' >> $LogFile
 
-# Sort and log MountList 
+# Sort and log MountList
 MountList=$(echo "$MountList" | sort -bu )
 echo 'MountList="'"$MountList"$'\n"' >> $LogFile
 echo '' >> $LogFile
 
 # Debloat by mounting in servise.sh
-for MountApk in $MountList
-do
+for MountApk in $MountList; do
 	PrintLine='$MountBind $DummyApk '"$MountApk"
 	echo "$PrintLine" >> $ServiceScript
 done
 
 
 # Log Stock apps and packages
-if [ ! -z "$VerboseLog" ]
-then
+if [ ! -z "$VerboseLog" ]; then
 	echo "Stock apps:"$'\n'"$StockAppList" >> $LogFile
 	echo "Stock packages: $PackageInfoList" >> $LogFile
 fi

--- a/update.json
+++ b/update.json
@@ -1,4 +1,4 @@
-{ 
+{
   "versionCode": 149,
   "version": "v1.4.9",
   "zipUrl": "https://github.com/zgfg/SystemlessDebloater/releases/download/149/SystemlessDebloater_v1.4.9.zip",


### PR DESCRIPTION
Remove extra spaces from the script file(s).

Adjust the 'if-then' and 'for-do' commands using `;` instead of a newline.